### PR TITLE
Fix sorting for blogs with <10 posts

### DIFF
--- a/cmd/ephemeris/main.go
+++ b/cmd/ephemeris/main.go
@@ -84,11 +84,6 @@ func getRecentPosts(posts []ephemeris.BlogEntry, count int) []ephemeris.BlogEntr
 	// The return-value
 	var recent []ephemeris.BlogEntry
 
-	// If there aren't too many posts then return them as-is.
-	if len(posts) <= count {
-		return posts
-	}
-
 	// Sort the list of posts by date.
 	sort.Slice(posts, func(i, j int) bool {
 		a := posts[i].Date
@@ -96,9 +91,13 @@ func getRecentPosts(posts []ephemeris.BlogEntry, count int) []ephemeris.BlogEntr
 		return a.Before(b)
 	})
 
-	// Build up the given number of posts.
+	// We want to include at-max `count` posts.
+	//
+	// But of course if this is a new blog there might
+	// be fewer than that present.  Terminate early in
+	// that case.
 	c := 0
-	for c < count {
+	for c < len(posts) && c < count {
 		ent := posts[len(posts)-1-c]
 		recent = append(recent, ent)
 		c++


### PR DESCRIPTION
As reported recently a blog which has fewer than ten posts will have the entries displayed in a random-order upon the front-page, and the list of recent posts in the sidebar.

The list of posts available in other views (tag, archive, etc) are all shown in the expected order.  The specific issue is the front-page and sidebar.

Looking at the code we retrieve the most recent posts for use upon the front/side via the following code:

```
func getRecentPosts(posts []ephemeris.BlogEntry, count int) []ephemeris.BlogEntry {

	// The return-value
	var recent []ephemeris.BlogEntry

	// If there aren't too many posts then return them as-is.
	if len(posts) <= count {
		return posts
	}

	// Sort the list of posts by date.
	..
}
```

Looking at this carefully reveals the problem:

* If there are fewer than ten posts (the value of `count`).
* Then we just return the list of posts we've found.
* Without sorting them.

To fix this we merely need to sort the posts, regardless of number, and ensure that we return the appropriate values:

* `count` if there are >= `count` posts.
* Otherwise however many there are, if there are fewer than `count`.

Closes #22.